### PR TITLE
Add usage tracking and plan entitlement tables

### DIFF
--- a/1769300000000_create-api-events-and-usage-counters.cjs
+++ b/1769300000000_create-api-events-and-usage-counters.cjs
@@ -1,0 +1,53 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable('api_events', {
+    id: 'bigserial',
+    tenant_id: { type: 'text', notNull: true },
+    endpoint: { type: 'text', notNull: true },
+    event_type: { type: 'text', notNull: true },
+    occurred_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    status_code: { type: 'integer' },
+    request_id: { type: 'text' },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+  }, { ifNotExists: true });
+
+  pgm.createIndex('api_events', ['tenant_id', 'occurred_at'], {
+    ifNotExists: true,
+    name: 'api_events_tenant_id_occurred_at_idx',
+  });
+  pgm.createIndex('api_events', ['tenant_id', 'endpoint', { name: 'occurred_at', sort: 'DESC' }], {
+    ifNotExists: true,
+    name: 'api_events_tenant_endpoint_time_idx',
+  });
+  pgm.createIndex('api_events', ['request_id'], { ifNotExists: true });
+
+  pgm.createTable('usage_counters', {
+    tenant_id: { type: 'text', notNull: true },
+    endpoint: { type: 'text', notNull: true },
+    period_start: { type: 'timestamptz', notNull: true },
+    call_count: { type: 'bigint', notNull: true, default: 0 },
+    last_updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  }, { ifNotExists: true });
+
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'usage_counters_pkey'
+      ) THEN
+        ALTER TABLE usage_counters
+          ADD CONSTRAINT usage_counters_pkey PRIMARY KEY (tenant_id, endpoint, period_start);
+      END IF;
+    END;
+    $$;
+  `);
+
+  pgm.createIndex('usage_counters', ['period_start'], { ifNotExists: true });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('usage_counters', { ifExists: true, cascade: true });
+  pgm.dropTable('api_events', { ifExists: true, cascade: true });
+};

--- a/1769300001000_create-idempotency-keys.cjs
+++ b/1769300001000_create-idempotency-keys.cjs
@@ -1,0 +1,26 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable('idempotency_keys', {
+    idempotency_key: { type: 'text', primaryKey: true },
+    tenant_id: { type: 'text', notNull: true },
+    endpoint: { type: 'text', notNull: true },
+    request_hash: { type: 'text', notNull: true },
+    response_body: { type: 'jsonb' },
+    status_code: { type: 'integer' },
+    locked_at: { type: 'timestamptz' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    expires_at: { type: 'timestamptz', notNull: true },
+    last_accessed_at: { type: 'timestamptz', default: pgm.func('now()') },
+  }, { ifNotExists: true });
+
+  pgm.createIndex('idempotency_keys', ['tenant_id', 'endpoint'], {
+    ifNotExists: true,
+    name: 'idempotency_keys_tenant_endpoint_idx',
+  });
+  pgm.createIndex('idempotency_keys', ['expires_at'], { ifNotExists: true });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('idempotency_keys', { ifExists: true, cascade: true });
+};

--- a/1769300002000_update-tenants-and-plan-entitlements.cjs
+++ b/1769300002000_update-tenants-and-plan-entitlements.cjs
@@ -1,0 +1,78 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable('plan_entitlements', {
+    plan_id: { type: 'text', primaryKey: true },
+    monthly_api_calls_total: { type: 'integer', notNull: true },
+    endpoint_overrides: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  }, { ifNotExists: true });
+
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'plan_entitlements_monthly_api_calls_total_check'
+      ) THEN
+        ALTER TABLE plan_entitlements
+          ADD CONSTRAINT plan_entitlements_monthly_api_calls_total_check
+          CHECK (monthly_api_calls_total >= 0);
+      END IF;
+    END;
+    $$;
+  `);
+
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'tenants'
+          AND column_name = 'plan'
+      ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'tenants'
+          AND column_name = 'plan_id'
+      ) THEN
+        ALTER TABLE public.tenants RENAME COLUMN plan TO plan_id;
+      END IF;
+    END;
+    $$;
+  `);
+
+  pgm.sql("ALTER TABLE public.tenants ADD COLUMN IF NOT EXISTS plan_id text NOT NULL DEFAULT 'free';");
+  pgm.sql('ALTER TABLE public.tenants ADD COLUMN IF NOT EXISTS quota_override jsonb;');
+};
+
+exports.down = (pgm) => {
+  pgm.sql('ALTER TABLE public.tenants DROP COLUMN IF EXISTS quota_override;');
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'tenants'
+          AND column_name = 'plan_id'
+      ) THEN
+        IF EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'tenants'
+            AND column_name = 'plan'
+        ) THEN
+          ALTER TABLE public.tenants DROP COLUMN plan_id;
+        ELSE
+          ALTER TABLE public.tenants RENAME COLUMN plan_id TO plan;
+        END IF;
+      END IF;
+    END;
+    $$;
+  `);
+
+  pgm.dropTable('plan_entitlements', { ifExists: true, cascade: true });
+};


### PR DESCRIPTION
## Summary
- add migrations that create api_events and usage_counters tables with supporting indexes
- add idempotency_keys table for safely reprocessing requests
- add plan_entitlements table and extend tenants with plan_id and quota overrides

## Testing
- not run (migrations only)


------
https://chatgpt.com/codex/tasks/task_e_68cb1f52322083239961e6fa95ca6705