### PR TITLE
feat: add billing core helpers

### DIFF
--- a/src/core/billing-map.mjs
+++ b/src/core/billing-map.mjs
@@ -1,0 +1,131 @@
+/**
+ * Central registry that describes how API endpoints are billed. Keeping the
+ * mapping in a single module allows middlewares, analytics collectors and
+ * worker jobs to rely on the same configuration when deciding whether a request
+ * should spend quota or credits.
+ */
+
+import { normalizeEndpoint } from './endpoint-normalize.mjs';
+
+const DEFAULT_WEIGHT = 1;
+const DEFAULT_METHOD_KEY = '*';
+
+const RAW_BILLABLE_DEFINITIONS = Object.freeze({
+    '/verify': {
+        POST: { billable: true, weight: 1, feature: 'verify' },
+    },
+    '/jobs/:id': {
+        GET: { billable: false, weight: 0 },
+    },
+    '/stamp': {
+        POST: { billable: true, weight: 1, feature: 'stamp' },
+    },
+    '/batch/upload': {
+        POST: { billable: true, weight: 1, feature: 'batch-upload' },
+    },
+    '/batch/:id/download': {
+        GET: { billable: false, weight: 0 },
+    },
+    '/usage': {
+        GET: { billable: false, weight: 0 },
+    },
+    '/quota': {
+        GET: { billable: false, weight: 0 },
+    },
+    '/billing': {
+        GET: { billable: false, weight: 0 },
+    },
+    '/analytics': {
+        GET: { billable: false, weight: 0 },
+    },
+});
+
+function normalizeMethodKey(method) {
+    if (!method) {
+        return DEFAULT_METHOD_KEY;
+    }
+    return method.toUpperCase();
+}
+
+function freezeMethodMap(methods) {
+    const entries = Object.entries(methods).map(([method, definition]) => {
+        const normalizedMethod = normalizeMethodKey(method);
+        const normalizedDefinition = Object.freeze({
+            billable: Boolean(definition.billable),
+            weight: Number.isFinite(definition.weight) ? Number(definition.weight) : DEFAULT_WEIGHT,
+            feature: definition.feature ?? undefined,
+        });
+        return [normalizedMethod, normalizedDefinition];
+    });
+
+    return new Map(entries);
+}
+
+function buildBillableMap(rawDefinitions) {
+    const map = new Map();
+    for (const [endpoint, methods] of Object.entries(rawDefinitions)) {
+        map.set(endpoint, freezeMethodMap(methods));
+    }
+    return map;
+}
+
+export const BILLABLE_MAP = buildBillableMap(RAW_BILLABLE_DEFINITIONS);
+
+/**
+ * Resolves billing information for a given HTTP method + path pair.
+ *
+ * @param {string} method - HTTP method.
+ * @param {string} path - Request path (may include query string).
+ * @returns {{ billable: boolean, weight: number, feature?: string }|null}
+ */
+export function getBillableDefinition(method, path) {
+    const normalizedPath = normalizeEndpoint(path);
+    const methodMap = BILLABLE_MAP.get(normalizedPath);
+    if (!methodMap) {
+        return null;
+    }
+
+    const normalizedMethod = normalizeMethodKey(method);
+    return methodMap.get(normalizedMethod) || methodMap.get(DEFAULT_METHOD_KEY) || null;
+}
+
+/**
+ * Returns whether the given request should count towards billing/quota.
+ *
+ * @param {string} method
+ * @param {string} path
+ * @returns {boolean}
+ */
+export function isBillable(method, path) {
+    const definition = getBillableDefinition(method, path);
+    return Boolean(definition && definition.billable);
+}
+
+/**
+ * Returns the billing weight for the given request. Non-billable requests return
+ * `0`.
+ *
+ * @param {string} method
+ * @param {string} path
+ * @returns {number}
+ */
+export function getBillableWeight(method, path) {
+    const definition = getBillableDefinition(method, path);
+    if (!definition || !definition.billable) {
+        return 0;
+    }
+    return definition.weight ?? DEFAULT_WEIGHT;
+}
+
+/**
+ * Usage example:
+ *
+ * ```js
+ * import { getBillableWeight, isBillable } from './core/billing-map.mjs';
+ *
+ * isBillable('POST', '/verify'); // true
+ * getBillableWeight('POST', '/verify'); // 1
+ *
+ * isBillable('GET', '/jobs/123'); // false (normalizes to `/jobs/:id`)
+ * ```
+ */

--- a/src/core/endpoint-normalize.mjs
+++ b/src/core/endpoint-normalize.mjs
@@ -1,0 +1,143 @@
+/**
+ * Utility helpers for normalizing API endpoint paths so that dynamic identifiers
+ * such as `/jobs/123` are mapped to canonical placeholders (e.g. `/jobs/:id`).
+ * This allows billing and analytics modules to reason about endpoints using a
+ * single source of truth regardless of the concrete identifiers that appear in
+ * runtime requests.
+ */
+
+const UUID_V4_REGEX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+const UUID_REGEX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+const HEX_24_REGEX = /^[0-9a-f]{24}$/i; // Mongo/ObjectId tarzı kimlikler.
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/; // ULID formatı.
+const BASE62_LONG_REGEX = /^[A-Za-z0-9_-]{16,}$/; // Uzun token benzeri kimlikler.
+const NUMERIC_ID_REGEX = /^\d+$/;
+
+const DEFAULT_MATCHERS = [
+    (segment) => NUMERIC_ID_REGEX.test(segment),
+    (segment) => UUID_V4_REGEX.test(segment) || UUID_REGEX.test(segment),
+    (segment) => HEX_24_REGEX.test(segment),
+    (segment) => ULID_REGEX.test(segment),
+    (segment) => BASE62_LONG_REGEX.test(segment),
+];
+
+function toDateSafe(value) {
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        throw new TypeError('normalizeEndpoint: invalid date value encountered');
+    }
+    return date;
+}
+
+function normalizePathInput(rawPath) {
+    if (typeof rawPath !== 'string') {
+        throw new TypeError('normalizeEndpoint: `path` must be a string.');
+    }
+
+    if (rawPath === '' || rawPath === '/') {
+        return '/';
+    }
+
+    const [pathOnly] = rawPath.split(/[?#]/, 1);
+    const trimmed = pathOnly.trim();
+    if (trimmed === '') {
+        return '/';
+    }
+
+    const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+    let collapsed = withLeadingSlash.replace(/\/{2,}/g, '/');
+    if (collapsed.length > 1 && collapsed.endsWith('/')) {
+        collapsed = collapsed.slice(0, -1);
+    }
+    return collapsed || '/';
+}
+
+/**
+ * Normalizes a concrete request path into its canonical representation.
+ *
+ * @example
+ * normalizeEndpoint('/jobs/12345'); // => '/jobs/:id'
+ *
+ * @param {string} path - Concrete HTTP path (may include query string).
+ * @param {Object} [options]
+ * @param {string} [options.placeholder=':id'] - Placeholder used for dynamic segments.
+ * @param {boolean} [options.preserveCase=false] - Keeps original segment casing.
+ * @param {Array<Function|RegExp>} [options.matchers] - Extra segment matchers.
+ * @returns {string} Normalized, leading-slash path (without query/fragment).
+ */
+export function normalizeEndpoint(path, options = {}) {
+    const {
+        placeholder = ':id',
+        preserveCase = false,
+        matchers = [],
+    } = options;
+
+    const normalizedBase = normalizePathInput(path);
+    if (normalizedBase === '/') {
+        return '/';
+    }
+
+    const compiledMatchers = matchers.map((matcher) => {
+        if (typeof matcher === 'function') {
+            return matcher;
+        }
+        if (matcher instanceof RegExp) {
+            return (segment) => matcher.test(segment);
+        }
+        throw new TypeError('normalizeEndpoint: `matchers` must be functions or RegExp instances.');
+    });
+
+    const segments = normalizedBase.split('/').filter(Boolean);
+    const detectors = [...DEFAULT_MATCHERS, ...compiledMatchers];
+
+    const normalizedSegments = segments.map((segment) => {
+        const shouldReplace = detectors.some((detector) => detector(segment));
+        if (shouldReplace) {
+            return placeholder;
+        }
+        return preserveCase ? segment : segment.toLowerCase();
+    });
+
+    return `/${normalizedSegments.join('/')}`;
+}
+
+/**
+ * Creates a pre-configured normalizer instance which can later be reused.
+ *
+ * @param {Object} [options] - Same options supported by {@link normalizeEndpoint}.
+ * @returns {(path: string) => string}
+ */
+export function createEndpointNormalizer(options = {}) {
+    return (path) => normalizeEndpoint(path, options);
+}
+
+/**
+ * Convenience helper for building Redis/metric keys using the normalized path
+ * together with a UTC month identifier.
+ *
+ * @param {string} path - Request path.
+ * @param {Date|number|string} [at=new Date()] - Reference time.
+ * @param {Object} [options]
+ * @returns {string}
+ */
+export function normalizeEndpointForMonth(path, at = new Date(), options = {}) {
+    const normalizedPath = normalizeEndpoint(path, options);
+    const date = toDateSafe(at);
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    return `${normalizedPath}@${year}-${month}`;
+}
+
+/**
+ * Usage example:
+ *
+ * ```js
+ * import { normalizeEndpoint, normalizeEndpointForMonth } from './core/endpoint-normalize.mjs';
+ *
+ * const normalized = normalizeEndpoint('/jobs/42');
+ * // normalized === '/jobs/:id'
+ *
+ * const monthlyKey = normalizeEndpointForMonth('/jobs/42', '2024-05-16T12:00:00Z');
+ * // monthlyKey === '/jobs/:id@2024-05'
+ * ```
+ */

--- a/src/core/time-window.mjs
+++ b/src/core/time-window.mjs
@@ -1,0 +1,110 @@
+/**
+ * Helpers for computing monthly billing windows. All calculations are performed
+ * in UTC midnight boundaries so that billing can be implemented consistently
+ * across tenants. The implementation is intentionally timezone-aware so that we
+ * can extend it in the future with tenant specific offsets without changing
+ * callers.
+ */
+
+function toDate(value) {
+    if (value instanceof Date) {
+        const time = value.getTime();
+        if (Number.isNaN(time)) {
+            throw new TypeError('time-window: Invalid Date object received.');
+        }
+        return new Date(time);
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        throw new TypeError('time-window: Unable to convert value to a valid Date.');
+    }
+    return date;
+}
+
+function createUtcDate(year, month, day = 1) {
+    return new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
+}
+
+/**
+ * Returns the UTC midnight representing the start of the month for the provided
+ * date.
+ *
+ * @param {Date|number|string} [reference=new Date()]
+ * @returns {Date}
+ */
+export function startOfUtcMonth(reference = new Date()) {
+    const date = toDate(reference);
+    return createUtcDate(date.getUTCFullYear(), date.getUTCMonth());
+}
+
+/**
+ * Returns the exclusive UTC midnight representing the first moment of the next
+ * month. Useful for range comparisons: `start <= x < end`.
+ *
+ * @param {Date|number|string} [reference=new Date()]
+ * @returns {Date}
+ */
+export function endOfUtcMonth(reference = new Date()) {
+    const date = toDate(reference);
+    return createUtcDate(date.getUTCFullYear(), date.getUTCMonth() + 1);
+}
+
+/**
+ * Returns the billing window boundaries for the month that contains `reference`.
+ *
+ * @param {Date|number|string} [reference=new Date()]
+ * @returns {{ start: Date, end: Date }}
+ */
+export function getMonthlyWindow(reference = new Date()) {
+    const start = startOfUtcMonth(reference);
+    const end = endOfUtcMonth(reference);
+    return { start, end };
+}
+
+/**
+ * Returns the billing window shifted by `offset` months relative to `reference`.
+ * A negative offset navigates backwards in time, positive goes forward.
+ *
+ * @param {number} [offset=0]
+ * @param {Date|number|string} [reference=new Date()]
+ * @returns {{ start: Date, end: Date }}
+ */
+export function getMonthlyWindowWithOffset(offset = 0, reference = new Date()) {
+    if (!Number.isInteger(offset)) {
+        throw new TypeError('time-window: `offset` must be an integer value.');
+    }
+
+    const date = toDate(reference);
+    const start = createUtcDate(date.getUTCFullYear(), date.getUTCMonth() + offset);
+    const end = createUtcDate(start.getUTCFullYear(), start.getUTCMonth() + 1);
+    return { start, end };
+}
+
+/**
+ * Returns a canonical key (`YYYY-MM`) suitable for Redis/metric storage.
+ *
+ * @param {Date|number|string} [reference=new Date()]
+ * @returns {string}
+ */
+export function getUtcMonthKey(reference = new Date()) {
+    const date = startOfUtcMonth(reference);
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    return `${year}-${month}`;
+}
+
+/**
+ * Usage example:
+ *
+ * ```js
+ * import { getMonthlyWindow, getUtcMonthKey } from './core/time-window.mjs';
+ *
+ * const { start, end } = getMonthlyWindow('2024-05-16T12:00:00Z');
+ * // start === 2024-05-01T00:00:00.000Z
+ * // end   === 2024-06-01T00:00:00.000Z
+ *
+ * const key = getUtcMonthKey(start);
+ * // key === '2024-05'
+ * ```
+ */


### PR DESCRIPTION
## Summary
- add a canonical billing map that exposes lookup helpers and default endpoint weights
- introduce endpoint normalization utilities to canonicalise dynamic request paths
- provide UTC-based monthly window helpers for consistent billing cycles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb238588c88323bd4139b47bec965a