### PR TITLE
Implement minimal management tenants endpoint

### DIFF
--- a/middleware/billing.js
+++ b/middleware/billing.js
@@ -7,6 +7,7 @@ const OPERATIONS = [
   { method: 'POST', pattern: /^\/verify$/i, name: '/verify', weight: 1 },
   { method: 'POST', pattern: /^\/stamp$/i, name: '/stamp', weight: 5 },
   { method: 'POST', pattern: /^\/batch\/upload$/i, name: '/batch/upload', weight: 10 },
+  { method: 'GET', pattern: /^\/management\/tenants$/i, name: '/management/tenants', billable: false },
   { method: 'POST', pattern: /^\/management\/keys$/i, name: '/management/keys', billable: false },
   {
     method: 'DELETE',

--- a/server.mjs
+++ b/server.mjs
@@ -920,6 +920,28 @@ app.get('/analytics', protect, ...billingReadChain, withFinalize(async (req, res
 
 // === PORTAL İÇİN YÖNETİM ENDPOINT'LERİ (OTURUM VE ROL KORUMALI) ===
 
+// Yönetim paneli için tenant listesini döner.
+app.get('/management/tenants', protect, authorize('admin'), async (req, res) => {
+    try {
+        const result = await dbPool.query(
+            `SELECT id, name, plan_id, created_at, updated_at FROM tenants ORDER BY created_at DESC`
+        );
+
+        const tenants = result.rows.map((row) => ({
+            id: row.id,
+            name: row.name,
+            planId: row.plan_id,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+        }));
+
+        res.status(200).json({ tenants });
+    } catch (error) {
+        req.log?.error?.({ err: error }, '[Mgmt] Tenant listesi alınamadı.');
+        return sendError(res, req, 500, 'TENANT_LIST_FAILED', 'Tenant listesi getirilemedi.');
+    }
+});
+
 // Bu endpoint artık kullanılmıyor, kayıt /auth/register üzerinden yapılıyor.
 // İstenirse admin paneli için yeniden düzenlenebilir.
 app.post('/management/tenants', protect, authorize('admin'), async (req, res) => {


### PR DESCRIPTION
## Summary
- add an admin-protected `/management/tenants` endpoint that lists tenant metadata including plan assignments
- mark the new management listing endpoint as non-billable in the billing middleware registry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbd187fa648323b363d87108ac93a8