### PR TITLE
Add quota exceeded banner and improve analytics state handling

### DIFF
--- a/de.json
+++ b/de.json
@@ -86,5 +86,10 @@
   "analytics_table_date": "Datum",
   "analytics_table_type": "Vorgangstyp",
   "analytics_table_status": "Status",
-  "analytics_table_duration": "Dauer (ms)"
+  "analytics_table_duration": "Dauer (ms)",
+  "analytics_error_generic": "Analysedaten konnten nicht geladen werden.",
+  "feedback_quota_exceeded": "Ihr Plan-Kontingent ist erschöpft. Bitte warten Sie auf die automatische Verlängerung oder upgraden Sie Ihren Tarif.",
+  "quota_banner_title": "Kontingent erreicht",
+  "quota_banner_message": "Ihr Plan-Kontingent ist erschöpft. Verbleibende Anfragen: {{remaining}}. Zurückgesetzt am: {{resetAt}}.",
+  "quota_banner_reset_unknown": "Unbekannt"
 }

--- a/en.json
+++ b/en.json
@@ -86,5 +86,10 @@
   "analytics_table_date": "Date",
   "analytics_table_type": "Operation Type",
   "analytics_table_status": "Status",
-  "analytics_table_duration": "Duration (ms)"
+  "analytics_table_duration": "Duration (ms)",
+  "analytics_error_generic": "We couldn't load the analytics data.",
+  "feedback_quota_exceeded": "Your plan quota has been exhausted. Please wait for it to reset or upgrade your plan.",
+  "quota_banner_title": "Quota Limit Reached",
+  "quota_banner_message": "Your plan quota has been exhausted. Remaining requests: {{remaining}}. Resets at: {{resetAt}}.",
+  "quota_banner_reset_unknown": "Unknown"
 }

--- a/es.json
+++ b/es.json
@@ -86,5 +86,10 @@
   "analytics_table_date": "Fecha",
   "analytics_table_type": "Tipo de operación",
   "analytics_table_status": "Estado",
-  "analytics_table_duration": "Duración (ms)"
+  "analytics_table_duration": "Duración (ms)",
+  "analytics_error_generic": "No pudimos cargar los datos de analítica.",
+  "feedback_quota_exceeded": "Tu cuota del plan se ha agotado. Espera a que se restablezca o mejora tu plan.",
+  "quota_banner_title": "Cuota alcanzada",
+  "quota_banner_message": "Tu cuota del plan se ha agotado. Solicitudes restantes: {{remaining}}. Se restablece el: {{resetAt}}.",
+  "quota_banner_reset_unknown": "Desconocido"
 }

--- a/index.html
+++ b/index.html
@@ -32,6 +32,13 @@
 
     <main class="app-main">
         <div class="view-stack">
+            <div id="quota-banner" class="quota-banner" hidden>
+                <div class="quota-banner__icon" aria-hidden="true">!</div>
+                <div class="quota-banner__content">
+                    <strong class="quota-banner__title" data-i18n="quota_banner_title"></strong>
+                    <p id="quota-banner-message" class="quota-banner__message"></p>
+                </div>
+            </div>
             <section id="login-view" class="view view--auth">
                 <article class="card card--form">
                     <h2 data-i18n="login_title">Giriş Yap</h2>

--- a/style.css
+++ b/style.css
@@ -140,6 +140,48 @@ img {
     justify-content: center;
 }
 
+.quota-banner {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(220, 38, 38, 0.35);
+    background: rgba(220, 38, 38, 0.1);
+    color: var(--danger);
+    box-shadow: var(--shadow-sm);
+}
+
+.quota-banner__icon {
+    font-size: 1.5rem;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    background: rgba(220, 38, 38, 0.15);
+    flex-shrink: 0;
+}
+
+.quota-banner__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.quota-banner__title {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.quota-banner__message {
+    margin: 0;
+    color: var(--text);
+    line-height: 1.4;
+}
+
 .view-stack {
     width: min(1200px, 100%);
     display: grid;

--- a/tr.json
+++ b/tr.json
@@ -86,5 +86,10 @@
   "analytics_table_date": "Tarih",
   "analytics_table_type": "İşlem Türü",
   "analytics_table_status": "Durum",
-  "analytics_table_duration": "Süre (ms)"
+  "analytics_table_duration": "Süre (ms)",
+  "analytics_error_generic": "Analitik verileri alınamadı.",
+  "feedback_quota_exceeded": "Plan kotanız tükendi. Lütfen paketinizin yenilenmesini bekleyin veya yükseltin.",
+  "quota_banner_title": "Kota Limitine Ulaşıldı",
+  "quota_banner_message": "Plan kotanız tükendi. Kalan istek: {{remaining}}. Yenilenme zamanı: {{resetAt}}.",
+  "quota_banner_reset_unknown": "Bilinmiyor"
 }


### PR DESCRIPTION
## Summary
- show a localized quota exceeded banner and disable write actions when the API returns `QUOTA_EXCEEDED`
- replace analytics placeholders with the live `/analytics` fetch and add loading, empty, and error states
- add translations and styles to support the new quota and analytics UX updates

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbd2654e608323981291fd879e51e4