### PR TITLE
Add billing quota basic flow verification report

### DIFF
--- a/reports/final/billing-basic.md
+++ b/reports/final/billing-basic.md
@@ -1,0 +1,60 @@
+# T17c — Billing/Quota Basic Flow Verification
+
+All requests were executed against the in-memory billing test harness via `node reports/scripts/run-billing-basic.mjs`, which uses Express + Supertest and the production `middleware/billing.js` flow. Tenant ID defaults to `tenant-a`.
+
+## Scenario 1 — POST /write below limit
+
+```http
+POST /write HTTP/1.1
+Content-Type: application/json
+
+{"sample":"payload"}
+```
+
+```
+HTTP/1.1 200 OK
+X-Quota-Remaining: 0
+{"ok":true}
+```
+
+Usage counters after finalize:
+
+```
+{"total":1,"endpoint":1}
+```
+
+## Scenario 2 — POST /write above limit
+
+```
+HTTP/1.1 429 Too Many Requests
+{"code":"QUOTA_EXCEEDED","remaining":0,"resetAt":"2024-01-31T23:59:59.999Z"}
+```
+
+Usage counters remain unchanged, confirming idempotent billing on rejection:
+
+```
+{"total":1,"endpoint":1}
+```
+
+## Scenario 3 — GET /write while quota exceeded
+
+```http
+GET /write HTTP/1.1
+```
+
+```
+HTTP/1.1 200 OK
+{"ok":true}
+```
+
+Usage counters stay unchanged:
+
+```
+{"total":1,"endpoint":1}
+```
+
+## Summary
+
+* Limit-altı POST isteği 200 döndü ve sayaç toplamı 1'e yükseldi.
+* Limit-üstü POST isteği 429 `{code:"QUOTA_EXCEEDED", remaining:0, resetAt:...}` yanıtı verdi.
+* Aynı anda yapılan GET isteği 200 başarılı döndü ve sayaç artmadı.

--- a/reports/scripts/run-billing-basic.mjs
+++ b/reports/scripts/run-billing-basic.mjs
@@ -1,0 +1,117 @@
+import express from 'express';
+import request from 'supertest';
+
+import {
+  configureBilling,
+  enforceQuota,
+  finalizeAndLog,
+  startTimer,
+} from '../../middleware/billing.js';
+import { MockDb, MockRedis } from '../../__tests__/helpers/mock-db.mjs';
+
+const NOW = new Date('2024-01-15T12:00:00.000Z');
+
+const waitForFinalize = async (iterations = 3) => {
+  for (let i = 0; i < iterations; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+};
+
+const createTestEnvironment = ({ limitsByTenant = { default: 1 } } = {}) => {
+  const db = new MockDb({ now: () => NOW });
+  const redis = new MockRedis();
+  const logger = { warn: () => {}, info: () => {}, error: () => {} };
+
+  configureBilling({ dbPool: db, redis, now: () => NOW, logger });
+
+  const app = express();
+  app.use(express.json());
+
+  const getLimitForTenant = (tenantId) => {
+    if (tenantId in limitsByTenant) return limitsByTenant[tenantId];
+    if ('default' in limitsByTenant) return limitsByTenant.default;
+    return null;
+  };
+
+  app.use((req, res, next) => {
+    const tenantId = req.get('X-Tenant-Id') || 'tenant-a';
+    const limit = getLimitForTenant(tenantId);
+
+    req.tenant = { id: tenantId };
+    req.billing = {
+      quota: { limit },
+    };
+    req.log = { warn: () => {}, error: () => {} };
+
+    if (!req.billing.__billingFinalizeAttached) {
+      finalizeAndLog(req, res);
+      req.billing.__billingFinalizeAttached = true;
+    }
+
+    next();
+  });
+
+  app.use(startTimer);
+
+  app.post('/write', enforceQuota, (req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  app.get('/write', enforceQuota, (req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  return { app, db };
+};
+
+const logJson = (label, payload) => {
+  const content = JSON.stringify(payload, null, 2);
+  console.log(`${label}:`);
+  console.log(content);
+};
+
+const main = async () => {
+  const { app, db } = createTestEnvironment({ limitsByTenant: { default: 1 } });
+
+  console.log('--- Scenario: POST /write below limit ---');
+  const first = await request(app).post('/write').send({ sample: 'payload' });
+  await waitForFinalize();
+  logJson('Response', {
+    status: first.status,
+    headers: { 'x-quota-remaining': first.headers['x-quota-remaining'] },
+    body: first.body,
+  });
+  logJson('Usage counters', {
+    total: db.getTotalUsage('tenant-a'),
+    endpoint: db.getUsage('tenant-a', '/write'),
+  });
+
+  console.log('\n--- Scenario: POST /write above limit ---');
+  const second = await request(app).post('/write').send({ sample: 'payload' });
+  await waitForFinalize();
+  logJson('Response', {
+    status: second.status,
+    body: second.body,
+  });
+  logJson('Usage counters', {
+    total: db.getTotalUsage('tenant-a'),
+    endpoint: db.getUsage('tenant-a', '/write'),
+  });
+
+  console.log('\n--- Scenario: GET /write while quota exceeded ---');
+  const third = await request(app).get('/write');
+  await waitForFinalize();
+  logJson('Response', {
+    status: third.status,
+    body: third.body,
+  });
+  logJson('Usage counters', {
+    total: db.getTotalUsage('tenant-a'),
+    endpoint: db.getUsage('tenant-a', '/write'),
+  });
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a reproducible Supertest script that exercises below/above quota flows
- document request/response samples for T17c billing quota verification

## Testing
- node reports/scripts/run-billing-basic.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc3c39e2ac83238aaa0f7d8130e553