### PR TITLE
test: cover analytics aggregation against fixtures

### DIFF
--- a/__tests__/analytics.integration.test.mjs
+++ b/__tests__/analytics.integration.test.mjs
@@ -1,0 +1,56 @@
+import { analyticsFixtures } from './fixtures/analytics.expected.mjs';
+import { fetchAnalytics } from './helpers/analytics.mjs';
+import { MockDb } from './helpers/mock-db.mjs';
+
+const INSERT_EVENT_SQL = `INSERT INTO api_events (tenant_id, endpoint, event_type, status_code, request_id, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6)`;
+
+const seedEvent = async (db, event, index) => {
+  const previousNow = db.now;
+  db.now = () => new Date(event.occurredAt);
+  try {
+    await db.query(INSERT_EVENT_SQL, [
+      event.tenantId,
+      event.endpoint,
+      event.eventType ?? 'POST',
+      event.status,
+      event.requestId ?? `req-${index}`,
+      { ...(event.metadata ?? {}), duration_ms: event.durationMs },
+    ]);
+  } finally {
+    db.now = previousNow;
+  }
+};
+
+describe('analytics aggregation uses real api_events data', () => {
+  test('hourly and daily aggregations match the analytics fixtures', async () => {
+    const db = new MockDb();
+    const tenantId = 'tenant-analytics';
+
+    const events = [
+      { tenantId, endpoint: '/videos/123', status: 201, occurredAt: '2024-03-10T10:05:00.000Z', durationMs: 45 },
+      { tenantId, endpoint: '/videos/456', status: 200, occurredAt: '2024-03-10T10:35:00.000Z', durationMs: 60 },
+      { tenantId, endpoint: '/videos/789', status: 404, occurredAt: '2024-03-10T11:15:00.000Z', durationMs: 30 },
+      { tenantId, endpoint: '/jobs/42', status: 503, occurredAt: '2024-03-11T09:20:00.000Z', durationMs: 120 },
+      { tenantId, endpoint: '/videos/000', status: 204, occurredAt: '2024-03-11T09:45:00.000Z', durationMs: 90 },
+      { tenantId: 'tenant-b', endpoint: '/videos/999', status: 200, occurredAt: '2024-03-10T10:10:00.000Z', durationMs: 70 },
+      { tenantId, endpoint: '/videos/out-of-range', status: 200, occurredAt: '2024-02-01T12:00:00.000Z', durationMs: 110 },
+    ];
+
+    for (const [index, event] of events.entries()) {
+      // Seed sequentially so that the mock database captures deterministic timestamps.
+      await seedEvent(db, event, index);
+    }
+
+    const range = {
+      from: new Date('2024-03-10T00:00:00.000Z'),
+      to: new Date('2024-03-11T23:59:59.999Z'),
+    };
+
+    const dailyAnalytics = await fetchAnalytics(db, tenantId, { ...range, groupBy: 'day' });
+    expect(dailyAnalytics).toEqual(analyticsFixtures.day);
+
+    const hourlyAnalytics = await fetchAnalytics(db, tenantId, { ...range, groupBy: 'hour' });
+    expect(hourlyAnalytics).toEqual(analyticsFixtures.hour);
+  });
+});

--- a/__tests__/billing.integration.test.mjs
+++ b/__tests__/billing.integration.test.mjs
@@ -9,7 +9,7 @@ import {
   finalizeAndLog,
 } from '../middleware/billing.js';
 import { MockDb, MockRedis } from './helpers/mock-db.mjs';
-import { normalizeEndpoint } from '../src/core/endpoint-normalize.mjs';
+import { fetchAnalytics } from './helpers/analytics.mjs';
 
 const NOW = new Date('2024-01-15T12:00:00.000Z');
 
@@ -17,117 +17,6 @@ const waitForFinalize = async (iterations = 3) => {
   for (let i = 0; i < iterations; i += 1) {
     await new Promise((resolve) => setImmediate(resolve));
   }
-};
-
-const fetchAnalytics = async (db, tenantId, { from, to, groupBy = 'day' }) => {
-  const toExclusive = new Date(to.getTime() + 1);
-  const fromIso = from.toISOString();
-  const toIso = toExclusive.toISOString();
-  const groupByParam = groupBy.toLowerCase();
-
-  const totalsResult = await db.query(
-    `SELECT
-        date_trunc($4::text, occurred_at) AS bucket,
-        COUNT(*)::bigint AS total,
-        COUNT(*) FILTER (WHERE status_code BETWEEN 200 AND 299)::bigint AS success_count,
-        COUNT(*) FILTER (WHERE status_code BETWEEN 400 AND 499)::bigint AS errors_4xx,
-        COUNT(*) FILTER (WHERE status_code BETWEEN 500 AND 599)::bigint AS errors_5xx
-      FROM api_events
-      WHERE tenant_id = $1
-        AND occurred_at >= $2::timestamptz
-        AND occurred_at < $3::timestamptz
-      GROUP BY bucket
-      ORDER BY bucket ASC;`,
-    [tenantId, fromIso, toIso, groupByParam],
-  );
-
-  const totals = totalsResult.rows.map((row) => {
-    const bucketDate = row.bucket instanceof Date ? row.bucket : new Date(row.bucket);
-    const total = Number(row.total || 0);
-    const success = Number(row.success_count || 0);
-    const errors4xx = Number(row.errors_4xx || 0);
-    const errors5xx = Number(row.errors_5xx || 0);
-    const errors = { '4xx': errors4xx, '5xx': errors5xx };
-
-    return {
-      bucket: bucketDate.toISOString(),
-      total,
-      success,
-      errors,
-      successRate: total > 0 ? success / total : 0,
-    };
-  });
-
-  const aggregate = totals.reduce(
-    (acc, row) => {
-      acc.total += row.total;
-      acc.success += row.success;
-      acc.errors['4xx'] += row.errors['4xx'];
-      acc.errors['5xx'] += row.errors['5xx'];
-      return acc;
-    },
-    { total: 0, success: 0, errors: { '4xx': 0, '5xx': 0 } },
-  );
-
-  const latencyResult = await db.query(
-    `WITH durations AS (
-        SELECT (metadata->>'duration_ms')::numeric AS value
-        FROM api_events
-        WHERE tenant_id = $1
-          AND occurred_at >= $2::timestamptz
-          AND occurred_at < $3::timestamptz
-          AND (metadata->>'duration_ms') ~ '^\\d+(?:\\.\\d+)?$'
-      )
-      SELECT
-        AVG(value) AS avg_duration,
-        PERCENTILE_DISC(0.95) WITHIN GROUP (ORDER BY value) AS p95_duration
-      FROM durations;`,
-    [tenantId, fromIso, toIso],
-  );
-
-  const latencyRow = latencyResult.rows[0] || {};
-  const latency = {
-    avg: latencyRow.avg_duration != null ? Number(latencyRow.avg_duration) : null,
-    p95: latencyRow.p95_duration != null ? Number(latencyRow.p95_duration) : null,
-  };
-
-  const topEndpointsResult = await db.query(
-    `SELECT endpoint, COUNT(*)::bigint AS count
-      FROM api_events
-      WHERE tenant_id = $1
-        AND occurred_at >= $2::timestamptz
-        AND occurred_at < $3::timestamptz
-      GROUP BY endpoint
-      ORDER BY count DESC
-      LIMIT 20;`,
-    [tenantId, fromIso, toIso],
-  );
-
-  const endpointAggregates = new Map();
-  for (const row of topEndpointsResult.rows) {
-    const rawEndpoint = typeof row.endpoint === 'string' ? row.endpoint : '/';
-    let normalized;
-    try {
-      normalized = normalizeEndpoint(rawEndpoint);
-    } catch (error) {
-      normalized = rawEndpoint || '/';
-    }
-    const current = endpointAggregates.get(normalized) ?? 0;
-    endpointAggregates.set(normalized, current + Number(row.count || 0));
-  }
-
-  const topEndpoints = Array.from(endpointAggregates.entries())
-    .map(([endpoint, count]) => ({ endpoint, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 5);
-
-  return {
-    totals,
-    successRate: aggregate.total > 0 ? aggregate.success / aggregate.total : 0,
-    errors: aggregate.errors,
-    latency,
-    topEndpoints,
-  };
 };
 
 const createTestEnvironment = ({

--- a/__tests__/fixtures/analytics.expected.mjs
+++ b/__tests__/fixtures/analytics.expected.mjs
@@ -1,0 +1,59 @@
+export const analyticsFixtures = {
+  day: {
+    totals: [
+      {
+        bucket: '2024-03-10T00:00:00.000Z',
+        total: 3,
+        success: 2,
+        errors: { '4xx': 1, '5xx': 0 },
+        successRate: 2 / 3,
+      },
+      {
+        bucket: '2024-03-11T00:00:00.000Z',
+        total: 2,
+        success: 1,
+        errors: { '4xx': 0, '5xx': 1 },
+        successRate: 1 / 2,
+      },
+    ],
+    successRate: 3 / 5,
+    errors: { '4xx': 1, '5xx': 1 },
+    latency: { avg: 69, p95: 90 },
+    topEndpoints: [
+      { endpoint: '/videos/:id', count: 4 },
+      { endpoint: '/jobs/:id', count: 1 },
+    ],
+  },
+  hour: {
+    totals: [
+      {
+        bucket: '2024-03-10T10:00:00.000Z',
+        total: 2,
+        success: 2,
+        errors: { '4xx': 0, '5xx': 0 },
+        successRate: 1,
+      },
+      {
+        bucket: '2024-03-10T11:00:00.000Z',
+        total: 1,
+        success: 0,
+        errors: { '4xx': 1, '5xx': 0 },
+        successRate: 0,
+      },
+      {
+        bucket: '2024-03-11T09:00:00.000Z',
+        total: 2,
+        success: 1,
+        errors: { '4xx': 0, '5xx': 1 },
+        successRate: 1 / 2,
+      },
+    ],
+    successRate: 3 / 5,
+    errors: { '4xx': 1, '5xx': 1 },
+    latency: { avg: 69, p95: 90 },
+    topEndpoints: [
+      { endpoint: '/videos/:id', count: 4 },
+      { endpoint: '/jobs/:id', count: 1 },
+    ],
+  },
+};

--- a/__tests__/helpers/analytics.mjs
+++ b/__tests__/helpers/analytics.mjs
@@ -1,0 +1,112 @@
+import { normalizeEndpoint } from '../../src/core/endpoint-normalize.mjs';
+
+export const fetchAnalytics = async (db, tenantId, { from, to, groupBy = 'day' }) => {
+  const toExclusive = new Date(to.getTime() + 1);
+  const fromIso = from.toISOString();
+  const toIso = toExclusive.toISOString();
+  const groupByParam = groupBy.toLowerCase();
+
+  const totalsResult = await db.query(
+    `SELECT
+        date_trunc($4::text, occurred_at) AS bucket,
+        COUNT(*)::bigint AS total,
+        COUNT(*) FILTER (WHERE status_code BETWEEN 200 AND 299)::bigint AS success_count,
+        COUNT(*) FILTER (WHERE status_code BETWEEN 400 AND 499)::bigint AS errors_4xx,
+        COUNT(*) FILTER (WHERE status_code BETWEEN 500 AND 599)::bigint AS errors_5xx
+      FROM api_events
+      WHERE tenant_id = $1
+        AND occurred_at >= $2::timestamptz
+        AND occurred_at < $3::timestamptz
+      GROUP BY bucket
+      ORDER BY bucket ASC;`,
+    [tenantId, fromIso, toIso, groupByParam],
+  );
+
+  const totals = totalsResult.rows.map((row) => {
+    const bucketDate = row.bucket instanceof Date ? row.bucket : new Date(row.bucket);
+    const total = Number(row.total || 0);
+    const success = Number(row.success_count || 0);
+    const errors4xx = Number(row.errors_4xx || 0);
+    const errors5xx = Number(row.errors_5xx || 0);
+    const errors = { '4xx': errors4xx, '5xx': errors5xx };
+
+    return {
+      bucket: bucketDate.toISOString(),
+      total,
+      success,
+      errors,
+      successRate: total > 0 ? success / total : 0,
+    };
+  });
+
+  const aggregate = totals.reduce(
+    (acc, row) => {
+      acc.total += row.total;
+      acc.success += row.success;
+      acc.errors['4xx'] += row.errors['4xx'];
+      acc.errors['5xx'] += row.errors['5xx'];
+      return acc;
+    },
+    { total: 0, success: 0, errors: { '4xx': 0, '5xx': 0 } },
+  );
+
+  const latencyResult = await db.query(
+    `WITH durations AS (
+        SELECT (metadata->>'duration_ms')::numeric AS value
+        FROM api_events
+        WHERE tenant_id = $1
+          AND occurred_at >= $2::timestamptz
+          AND occurred_at < $3::timestamptz
+          AND (metadata->>'duration_ms') ~ '^\\\d+(?:\\.\\d+)?$'
+      )
+      SELECT
+        AVG(value) AS avg_duration,
+        PERCENTILE_DISC(0.95) WITHIN GROUP (ORDER BY value) AS p95_duration
+      FROM durations;`,
+    [tenantId, fromIso, toIso],
+  );
+
+  const latencyRow = latencyResult.rows[0] || {};
+  const latency = {
+    avg: latencyRow.avg_duration != null ? Number(latencyRow.avg_duration) : null,
+    p95: latencyRow.p95_duration != null ? Number(latencyRow.p95_duration) : null,
+  };
+
+  const topEndpointsResult = await db.query(
+    `SELECT endpoint, COUNT(*)::bigint AS count
+      FROM api_events
+      WHERE tenant_id = $1
+        AND occurred_at >= $2::timestamptz
+        AND occurred_at < $3::timestamptz
+      GROUP BY endpoint
+      ORDER BY count DESC
+      LIMIT 20;`,
+    [tenantId, fromIso, toIso],
+  );
+
+  const endpointAggregates = new Map();
+  for (const row of topEndpointsResult.rows) {
+    const rawEndpoint = typeof row.endpoint === 'string' ? row.endpoint : '/';
+    let normalized;
+    try {
+      normalized = normalizeEndpoint(rawEndpoint);
+    } catch (error) {
+      normalized = rawEndpoint || '/';
+    }
+    const current = endpointAggregates.get(normalized) ?? 0;
+    endpointAggregates.set(normalized, current + Number(row.count || 0));
+  }
+
+  const topEndpoints = Array.from(endpointAggregates.entries())
+    .map(([endpoint, count]) => ({ endpoint, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  return {
+    totals,
+    successRate: aggregate.total > 0 ? aggregate.success / aggregate.total : 0,
+    errors: aggregate.errors,
+    latency,
+    topEndpoints,
+  };
+};


### PR DESCRIPTION
## Summary
- extract analytics aggregation helper for reuse across tests
- add fixture-backed integration coverage for hourly and daily analytics buckets
- pin expected totals, latency, errors, and top endpoints in fixtures to ensure real api_events data powers analytics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc3fc58ef483239f5d28779d90650f