### PR TITLE
Align usage/analytics error responses with docs

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -65,6 +65,7 @@ Tenant'ın mevcut faturalandırılabilir istek kullanımını döner.
 | 401   | `AUTHENTICATION_REQUIRED`   | Kimlik doğrulaması eksik veya geçersiz. |
 | 403   | `TENANT_MISSING`            | Oturum bağlamında tenant yok (koruyucu middleware'lerden gelebilir). |
 | 429   | `READ_RATE_LIMIT_EXCEEDED`  | Planın GET oran sınırı aşıldı. |
+| 500   | `TENANT_RESOLUTION_FAILED`  | Tenant bağlamı çözülemedi (iç hata). |
 | 500   | `READ_RATE_LIMIT_FAILURE`   | Okuma oranı sınırlayıcısı kullanılamıyor (geçici hata). |
 
 Tüm hata yanıtları standart hata şemasını kullanır.
@@ -145,6 +146,7 @@ Alanlar:
 | 403   | `TENANT_MISMATCH`            | Oturum tenant'ı dışında bir tenant talep edildi. |
 | 401   | `AUTHENTICATION_REQUIRED`    | Kimlik doğrulaması yok. |
 | 429   | `READ_RATE_LIMIT_EXCEEDED`   | Okuma oran sınırı aşıldı. |
+| 500   | `TENANT_RESOLUTION_FAILED`   | Tenant bağlamı çözülemedi (iç hata). |
 | 500   | `ANALYTICS_FETCH_FAILED`     | Analitik verileri alınırken beklenmeyen hata. |
 | 500   | `READ_RATE_LIMIT_FAILURE`    | Okuma oranı sınırlayıcısı başarısız oldu. |
 

--- a/middleware/billing.js
+++ b/middleware/billing.js
@@ -452,19 +452,19 @@ export const resolveTenant = async (req, res, next) => {
       if (!tenantId) {
         const apiKey = req.get('X-API-Key');
         if (!apiKey) {
-          return res.status(401).json({ code: 'AUTH_REQUIRED', message: 'X-API-Key header required.' });
+          return sendError(res, req, 403, 'TENANT_MISSING', 'Tenant context is required.');
         }
 
         billing.apiKey = apiKey;
         tenantId = await resolveTenantIdFromApiKey(apiKey, { redis, dbPool });
         if (!tenantId) {
-          return res.status(401).json({ code: 'INVALID_API_KEY', message: 'API key is not recognized.' });
+          return sendError(res, req, 401, 'AUTHENTICATION_REQUIRED', 'Authentication required.');
         }
       }
 
       tenant = await loadTenantById(tenantId, { redis, dbPool });
       if (!tenant) {
-        return res.status(404).json({ code: 'TENANT_NOT_FOUND', message: 'Tenant context could not be resolved.' });
+        return sendError(res, req, 403, 'TENANT_MISSING', 'Tenant context is required.');
       }
     }
 
@@ -488,7 +488,7 @@ export const resolveTenant = async (req, res, next) => {
     next();
   } catch (error) {
     req.log?.error?.({ err: error }, '[billing] resolveTenant failed');
-    res.status(500).json({ code: 'TENANT_RESOLUTION_FAILED' });
+    return sendError(res, req, 500, 'TENANT_RESOLUTION_FAILED', 'Tenant context could not be resolved.');
   }
 };
 

--- a/reports/final/api-contracts.md
+++ b/reports/final/api-contracts.md
@@ -1,0 +1,26 @@
+# API Contract Doğrulama — `/usage`, `/analytics`
+
+## Kapsam
+- `GET /usage`
+- `GET /analytics`
+- Standart hata yanıtı şeması
+
+## Uygulama İncelemesi
+- Hata yanıtları `http-error.js` içindeki `sendError` fonksiyonu tarafından üretilir ve her yanıta `code`, `message`, `requestId` alanlarını ekler; varsa `details` alanı da döner. 【F:http-error.js†L5-L49】
+- Kimliği doğrulanmış isteklerde tenant bağlamı `resolveTenant` ile çözümlenir; başarısız durumlarda standart hata şeması ve sözleşmedeki kodlar (`TENANT_MISSING`, `AUTHENTICATION_REQUIRED`, `TENANT_RESOLUTION_FAILED`) kullanılır. 【F:middleware/billing.js†L443-L492】
+
+### `GET /usage`
+- Uç nokta tenant'ın içinde bulunulan ay için toplam faturalandırılabilir çağrı sayısını `requests_used` alanı ile döner. 【F:server.mjs†L813-L819】
+- Başarılı yanıtlarda plan bazlı oran limitleri için `X-RateLimit-*` başlıkları middleware tarafından ayarlanır. 【F:middleware/billing.js†L471-L488】
+- Hata durumları dokümandaki tablo ile örtüşür: kimlik doğrulaması eksikse `401 AUTHENTICATION_REQUIRED`, tenant çözümlenemediğinde `403 TENANT_MISSING`, okuma oran limiti aşıldığında `429 READ_RATE_LIMIT_EXCEEDED`, içsel çözümleme hatalarında `500 TENANT_RESOLUTION_FAILED`/`READ_RATE_LIMIT_FAILURE`. 【F:middleware/billing.js†L443-L492】【F:docs/api-contracts.md†L63-L71】
+
+### `GET /analytics`
+- Sorgu parametreleri `tenantId`, `from`/`to` (`startDate`/`endDate` eşdeğeri) ve `groupBy` (`hour` veya `day`) olarak ayrıştırılır; geçersiz değerlerde uygun `400` kodları döner. 【F:server.mjs†L853-L893】
+- Yanıt gövdesi toplamlar, başarı oranı, hata kırılımları, gecikme metrikleri ve en çok çağrılan uç noktaları içerir; değerler SQL sorguları ile hesaplanır ve sözleşmedeki alan adları bire bir eşleşir. 【F:server.mjs†L900-L999】
+- Tenant çözümleme ve oran limiti hataları `/usage` ile aynı kodları üretir; analitik derleme sırasında beklenmeyen hata oluşursa `500 ANALYTICS_FETCH_FAILED` döner. 【F:server.mjs†L900-L1003】【F:docs/api-contracts.md†L139-L151】
+
+## Doküman Güncellemesi
+- `docs/api-contracts.md` hata tabloları, uygulamadaki `TENANT_RESOLUTION_FAILED` kodunu da kapsayacak şekilde güncellendi. 【F:docs/api-contracts.md†L63-L151】
+
+## Sonuç
+- Yapılan düzeltmelerle birlikte uygulama yanıtları ile dokümantasyon bire bir uyumludur; sapma tespit edilmemiştir.


### PR DESCRIPTION
## Summary
- ensure billing resolveTenant middleware returns standard error payloads and codes for auth and tenant resolution failures
- document tenant resolution failures in the usage and analytics API contract tables
- add final API contract verification report covering /usage and /analytics endpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5acb99888323bb8c65a0c44e6faa