### PR TITLE
Fix billing counters and analytics rollups

### DIFF
--- a/__tests__/billing.unit.test.mjs
+++ b/__tests__/billing.unit.test.mjs
@@ -85,13 +85,17 @@ describe('billing unit helpers', () => {
     const period = '2024-01';
 
     const first = await incrementUsageAtomic('tenant-a', '/write', 2, period, { limit: 10 });
-    expect(first).toEqual({ allowed: true, total: 2, endpointUsage: 2 });
+    expect(first).toEqual(
+      expect.objectContaining({ allowed: true, total: 2, endpointUsage: 2, totalCount: 1, endpointCount: 1 }),
+    );
 
     const second = await incrementUsageAtomic('tenant-a', '/write', 1, period, { limit: 10 });
-    expect(second).toEqual({ allowed: true, total: 3, endpointUsage: 3 });
+    expect(second).toEqual(
+      expect.objectContaining({ allowed: true, total: 3, endpointUsage: 3, totalCount: 2, endpointCount: 2 }),
+    );
 
     expect(db.getTotalUsage('tenant-a')).toBe(3);
-    expect(db.getUsage('tenant-a', '/write')).toBe(3);
+    expect(db.getUsage('tenant-a', '/write')).toBe(2);
   });
 
   test('incrementUsageAtomic enforces limits before incrementing', async () => {

--- a/migrations/1769300004000_create_api_events_rollups.cjs
+++ b/migrations/1769300004000_create_api_events_rollups.cjs
@@ -1,0 +1,70 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable(
+    'api_events_rollup_hourly',
+    {
+      bucket_ts: { type: 'timestamptz', notNull: true },
+      tenant_id: { type: 'text', notNull: true },
+      endpoint: { type: 'text', notNull: true },
+      calls: { type: 'bigint', notNull: true, default: 0 },
+      success: { type: 'bigint', notNull: true, default: 0 },
+      errors4xx: { type: 'bigint', notNull: true, default: 0 },
+      errors5xx: { type: 'bigint', notNull: true, default: 0 },
+      avg_ms: { type: 'integer' },
+      p95_ms: { type: 'integer' },
+      created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+      updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    },
+    { ifNotExists: true },
+  );
+
+  pgm.addConstraint('api_events_rollup_hourly', 'api_events_rollup_hourly_pkey', {
+    primaryKey: ['bucket_ts', 'tenant_id', 'endpoint'],
+  });
+
+  pgm.createIndex('api_events_rollup_hourly', ['tenant_id', { name: 'bucket_ts', sort: 'DESC' }], {
+    ifNotExists: true,
+    name: 'api_events_rollup_hourly_tenant_bucket_idx',
+  });
+  pgm.createIndex('api_events_rollup_hourly', ['bucket_ts'], {
+    ifNotExists: true,
+    name: 'api_events_rollup_hourly_bucket_idx',
+  });
+
+  pgm.createTable(
+    'api_events_rollup_daily',
+    {
+      bucket_ts: { type: 'timestamptz', notNull: true },
+      tenant_id: { type: 'text', notNull: true },
+      endpoint: { type: 'text', notNull: true },
+      calls: { type: 'bigint', notNull: true, default: 0 },
+      success: { type: 'bigint', notNull: true, default: 0 },
+      errors4xx: { type: 'bigint', notNull: true, default: 0 },
+      errors5xx: { type: 'bigint', notNull: true, default: 0 },
+      avg_ms: { type: 'integer' },
+      p95_ms: { type: 'integer' },
+      created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+      updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    },
+    { ifNotExists: true },
+  );
+
+  pgm.addConstraint('api_events_rollup_daily', 'api_events_rollup_daily_pkey', {
+    primaryKey: ['bucket_ts', 'tenant_id', 'endpoint'],
+  });
+
+  pgm.createIndex('api_events_rollup_daily', ['tenant_id', { name: 'bucket_ts', sort: 'DESC' }], {
+    ifNotExists: true,
+    name: 'api_events_rollup_daily_tenant_bucket_idx',
+  });
+  pgm.createIndex('api_events_rollup_daily', ['bucket_ts'], {
+    ifNotExists: true,
+    name: 'api_events_rollup_daily_bucket_idx',
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('api_events_rollup_daily', { ifExists: true, cascade: true });
+  pgm.dropTable('api_events_rollup_hourly', { ifExists: true, cascade: true });
+};


### PR DESCRIPTION
## Summary
- add migrations for hourly/daily API event rollup tables with indexes
- update analytics job to auto-detect API event schema and write to new rollup structure
- persist both call counts and weights through middleware, Redis flush job, and unit helpers
- document logs and verification steps in FINAL-READINESS-REPORT.md

## Testing
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/videokit_hotfix npm run migrate:up
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/videokit_hotfix npm run migrate:down -- --to 0
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/videokit_hotfix npm run migrate:down -- --to 0
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/videokit_hotfix npm run migrate:up
- node - <<'NODE' ... incrementUsageAtomic ... NODE
- psql postgres://postgres:postgres@localhost:5432/videokit_hotfix -c "SELECT endpoint, count, total_weight FROM usage_counters ORDER BY endpoint"
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/videokit_hotfix REDIS_URL=redis://localhost:6379 DEFAULT_PLAN_LIMIT=1000 BILLING_ENFORCEMENT=true ANALYTICS_LOGGING=false STORAGE_TTL_DAYS=30 npm run job:rollup-analytics
- redis-cli HSET usage:tenant-hotfix:2025-09 __total__ 2 __total_count__ 1 op:/verify 2 op_count:/verify 1
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/videokit_hotfix REDIS_URL=redis://127.0.0.1:6379 DEFAULT_PLAN_LIMIT=1000 BILLING_ENFORCEMENT=true ANALYTICS_LOGGING=false STORAGE_TTL_DAYS=30 npm run job:flush-usage
- psql postgres://postgres:postgres@localhost:5432/videokit_hotfix -c "SELECT endpoint, count, total_weight FROM usage_counters ORDER BY endpoint"
- npm test -- --runTestsByPath __tests__/billing.unit.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cd04c54e388323ab107301f3f00a23